### PR TITLE
Update freon.langium grammar: changed 'scope' to 'namespace-replacement'

### DIFF
--- a/src/language/freon.langium
+++ b/src/language/freon.langium
@@ -256,7 +256,7 @@ KeywordAllowedAsProperty returns string:
     | 'abstract' | 'precedence' | 'priority' | 'reference' | 'true' | 'false' | 'for' | 'in'
     | 'rows' | 'columns' | 'wrap' | 'replace' | 'expression' | 'binary' | 'limited'
     | 'fragment' | 'external' | 'type' | 'file-extension'
-    | 'scoper' | 'namespace_addition' | 'isnamespace' | 'scope'
+    | 'scoper' | 'namespace_addition' | 'isnamespace' | 'namespace-replacement'
     | 'typer' | 'validator'
     | ListInfoType
     | TEXT


### PR DESCRIPTION
This brings Freon-IDE inline with the changes in branch 'scoper-tryout' in freon4dsl.